### PR TITLE
make diatex more configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,45 @@
 .bundle
+
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+# Used by dotenv library to load environment variables.
+# .env
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'byebug'
-gem 'octokit'
-gem 'phantomjs'
-gem 'minitest', '~> 5.0'
-gem 'mocha'
+group :test, :development do
+  gem 'byebug'
 
+  gem 'minitest', '~> 5.0'
+  gem 'mocha'
+  gem 'vcr'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
     byebug (9.0.6)
-    faraday (0.9.2)
-      multipart-post (>= 1.2, < 3)
     metaclass (0.0.4)
     minitest (5.10.1)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
-    multipart-post (2.0.0)
-    octokit (4.2.0)
-      sawyer (~> 0.6.0, >= 0.5.3)
-    phantomjs (2.1.1.0)
-    sawyer (0.6.0)
-      addressable (~> 2.3.5)
-      faraday (~> 0.8, < 0.10)
+    vcr (3.0.3)
 
 PLATFORMS
   ruby
@@ -24,8 +15,7 @@ DEPENDENCIES
   byebug
   minitest (~> 5.0)
   mocha
-  octokit
-  phantomjs
+  vcr
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/lib/diatex.rb
+++ b/lib/diatex.rb
@@ -16,6 +16,7 @@ module Diatex
     (?!\n?--->)$                  # Make sure it's really not a comment
   /x
 
+  IGNORED_DIRS = %w(jekyll)
   module CLI
     def self.run(*argv)
       # Make sure env is setup
@@ -23,11 +24,11 @@ module Diatex
       # Make sure directory is provide and exists as a directory
       # raise 'Did not provide a path as an argument' if argv[0].nil?
       # raise "Path #{argv[0]} did not exist as a directory" if !File.exist?(argv[0]) || !File.directory?(argv[0])
-      blacklist = %w(jekyll)
       # Parse all markdown files in specified directory
-      files = Dir["#{argv[0]}/**/*.md"].reject { |file| blacklist.any?{ |folder| file.start_with?(folder) } }
-      files.each do |file|
+
+      Dir["#{argv[0]}/**/*.md"].each do |file|
         print(file)
+        next if IGNORED_DIRS.any? { |folder| File.dirname(file).include?(folder) }
         old_content = File.read(file)
         new_content = Diatex.process(old_content, local: argv[1] == 'local')
         File.write(file, new_content)

--- a/lib/diatex.rb
+++ b/lib/diatex.rb
@@ -21,11 +21,12 @@ module Diatex
       # Make sure env is setup
       raise 'Did not provide DIATEX_PASSWORD env var' if ENV['DIATEX_PASSWORD'].nil? && argv[1] != 'local'
       # Make sure directory is provide and exists as a directory
-      raise 'Did not provide a path as an argument' if argv[0].nil?
-      raise "Path #{argv[0]} did not exist as a directory" if !File.exist?(argv[0]) || !File.directory?(argv[0])
-
+      # raise 'Did not provide a path as an argument' if argv[0].nil?
+      # raise "Path #{argv[0]} did not exist as a directory" if !File.exist?(argv[0]) || !File.directory?(argv[0])
+      blacklist = %w(jekyll)
       # Parse all markdown files in specified directory
-      Dir["#{argv[0]}/**/*.md"].each do |file|
+      files = Dir["#{argv[0]}/**/*.md"].reject { |file| blacklist.any?{ |folder| file.start_with?(folder) } }
+      files.each do |file|
         print(file)
         old_content = File.read(file)
         new_content = Diatex.process(old_content, local: argv[1] == 'local')

--- a/lib/diatex.rb
+++ b/lib/diatex.rb
@@ -3,8 +3,6 @@ require 'net/http'
 require 'cgi'
 require 'json'
 
-require 'byebug'
-
 module Diatex
   REGEX = /
     ^(?<!<!---\n)                 # Make sure it's not a comment

--- a/lib/diatex.rb
+++ b/lib/diatex.rb
@@ -3,6 +3,8 @@ require 'net/http'
 require 'cgi'
 require 'json'
 
+require 'byebug'
+
 module Diatex
   REGEX = /
     ^(?<!<!---\n)                 # Make sure it's not a comment
@@ -27,8 +29,8 @@ module Diatex
       # Parse all markdown files in specified directory
 
       Dir["#{argv[0]}/**/*.md"].each do |file|
-        print(file)
         next if IGNORED_DIRS.any? { |folder| File.dirname(file).include?(folder) }
+        print(file)
         old_content = File.read(file)
         new_content = Diatex.process(old_content, local: argv[1] == 'local')
         File.write(file, new_content)
@@ -81,7 +83,8 @@ module Diatex
     def diagram_image_url(content)
       body = { diagram: content }
       uri = URI("#{url}/diagram")
-      fetch_response(uri, body)
+      response = fetch_response(uri, body)
+      File.join(image_base_path, response) if response
     end
 
     def fetch_response(uri, body)

--- a/lib/diatex.rb
+++ b/lib/diatex.rb
@@ -51,13 +51,8 @@ module Diatex
     private
 
     def url
-      if ENV['DIATEX_URL']
-        ENV['DIATEX_URL']
-      elsif ENV['DEVELOPMENT']
-        'http://localhost:3000'
-      else
-        'https://jnadeau.ca/diatex'
-      end
+      return 'http://localhost:3000' if ENV['DEVELOPMENT']
+      ENV.fetch('DIATEX_URL' ,'https://jnadeau.ca/diatex')
     end
 
     def git_cdn_repo

--- a/test/diatex_test.rb
+++ b/test/diatex_test.rb
@@ -1,17 +1,43 @@
 require 'test_helper'
 
 class DiatexTest < MiniTest::Test
+  def setup
+    ENV['DEVELOPMENT'] = nil
+    ENV["DIATEX_URL"] = nil
+    ENV["DIATEX_CDN_REPO"] = nil
+    ENV["DIATEX_IMAGE_BASE_PATH"] = nil
+  end
+
   def test_latex_image_url
-    ENV['DEVELOPMENT'] = "true"
     VCR.use_cassette("latex_image_request") do
+      ENV['DEVELOPMENT'] = "true"
       url = Diatex.send(:latex_image_url, "f(x)=5y")
       assert_equal "http://gitcdn.jnadeau.ca/images/diatex/latex/ce645fe7a0e3d8b384fd64ff7a47c9d9.png", url
-      byebug
     end
   end
 
-  # WebMock::RequestRegistry.instance.requested_signatures.each { |a| puts a.uri }
+  def test_diagram_image_url
+    VCR.use_cassette("diagram_image_request") do
+      ENV['DEVELOPMENT'] = "true"
+      url = Diatex.send(:diagram_image_url, "f(x)=5y")
+      assert_equal "http://gitcdn.jnadeau.ca/images/diatex/diagram/ce645fe7a0e3d8b384fd64ff7a47c9d9.png", url
+    end
+  end
 
-  def test_latex_image_url_request_parameters
+  def test_latex_image_env_options
+    VCR.use_cassette("latex_image_env_options") do
+      ENV["DIATEX_URL"] = "https://diatex.mydomain.com"
+      ENV["DIATEX_CDN_REPO"] = "myawesomeuser/gitcdn"
+      ENV["DIATEX_IMAGE_BASE_PATH"] = "https://gitcdn.mydomain.com"
+      url = Diatex.send(:latex_image_url, "f(x)=5y+y")
+      # should only be one request
+      WebMock::RequestRegistry.instance.requested_signatures.each do |request|
+        assert_equal "https://diatex.mydomain.com:443/latex", request.uri.to_s
+        request_params = CGI::parse(request.body)
+        assert_equal ["f%28x%29%3D5y%2By"], request_params["latex"]
+        assert_equal ["myawesomeuser/gitcdn"], request_params["github_repo"]
+      end
+      assert_equal "https://gitcdn.mydomain.com/images/diatex/latex/ce645fe7a0e3d8b384fd64ff7a47c9d9.png", url
+    end
   end
 end

--- a/test/diatex_test.rb
+++ b/test/diatex_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'byebug'
 
 class DiatexTest < MiniTest::Test
   def test_latex_image_url
@@ -7,8 +6,11 @@ class DiatexTest < MiniTest::Test
     VCR.use_cassette("latex_image_request") do
       url = Diatex.send(:latex_image_url, "f(x)=5y")
       assert_equal "http://gitcdn.jnadeau.ca/images/diatex/latex/ce645fe7a0e3d8b384fd64ff7a47c9d9.png", url
+      byebug
     end
   end
+
+  # WebMock::RequestRegistry.instance.requested_signatures.each { |a| puts a.uri }
 
   def test_latex_image_url_request_parameters
   end

--- a/test/diatex_test.rb
+++ b/test/diatex_test.rb
@@ -1,10 +1,15 @@
 require 'test_helper'
+require 'byebug'
 
 class DiatexTest < MiniTest::Test
-  def test_nothing
-    inp = '# header'
-    exp = '# header'
-    act = Diatex.process(inp)
-    assert_equal(exp, act)
+  def test_latex_image_url
+    ENV['DEVELOPMENT'] = "true"
+    VCR.use_cassette("latex_image_request") do
+      url = Diatex.send(:latex_image_url, "f(x)=5y")
+      assert_equal "http://gitcdn.jnadeau.ca/images/diatex/latex/ce645fe7a0e3d8b384fd64ff7a47c9d9.png", url
+    end
+  end
+
+  def test_latex_image_url_request_parameters
   end
 end

--- a/test/fixtures/vcr_cassettes/diagram_image_request.yml
+++ b/test/fixtures/vcr_cassettes/diagram_image_request.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/diagram
+    body:
+      encoding: US-ASCII
+      string: diagram=f%28x%29%3D5y
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZGlhdGV4Og==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '86'
+    body:
+      encoding: UTF-8
+      string: '{"input":"f(x)=5y","url":"images/diatex/diagram/ce645fe7a0e3d8b384fd64ff7a47c9d9.png"}'
+    http_version:
+  recorded_at: Sat, 01 Apr 2017 22:38:59 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/latex_image_env_options.yml
+++ b/test/fixtures/vcr_cassettes/latex_image_env_options.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://diatex.mydomain.com/latex
+    body:
+      encoding: US-ASCII
+      string: latex=f%2528x%2529%253D5y%252By&github_repo=myawesomeuser%2Fgitcdn
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZGlhdGV4Og==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: '{"input":"f(x)=5y","url":"images/diatex/latex/ce645fe7a0e3d8b384fd64ff7a47c9d9.png"}'
+    http_version:
+  recorded_at: Sat, 01 Apr 2017 22:12:44 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/latex_image_request.yml
+++ b/test/fixtures/vcr_cassettes/latex_image_request.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/latex
+    body:
+      encoding: US-ASCII
+      string: latex=f%2528x%2529%253D5y
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZGlhdGV4Og==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: '{"input":"f(x)=5y","url":"images/diatex/latex/ce645fe7a0e3d8b384fd64ff7a47c9d9.png"}'
+    http_version:
+  recorded_at: Sat, 01 Apr 2017 04:41:38 GMT
+recorded_with: VCR 3.0.3

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require 'mocha'
+require 'byebug'
 
 path = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,8 +10,8 @@ require 'webmock/minitest'
 require 'vcr'
 
 VCR.configure do |config|
-  config.cassette_library_dir = "test/fixtures/vcr_cassettes"
   config.hook_into :webmock
+  config.cassette_library_dir = "test/fixtures/vcr_cassettes"
 end
 
 require 'diatex'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,4 +4,13 @@ require 'mocha'
 path = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
 
+require 'webmock/minitest'
+
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "test/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
+
 require 'diatex'


### PR DESCRIPTION
Basically just adds some environment variables to configure diatex:
- DIATEX_IMAGE_BASE_PATH: base path for return values from diatex
- DIATEX_CDN_REPO: GitHub cdn repo to pass to the server
- DIATEX_URL: location of the diatex server

This will allow me to use diatex_server

Also added some tests because the test file was looking sad

I don't think the only breaking change here is changing the request to post from get

@jules2689 